### PR TITLE
Added user dialog and change user/password views

### DIFF
--- a/client/src/components/Header/NavBar.js
+++ b/client/src/components/Header/NavBar.js
@@ -3,11 +3,11 @@ import { useLocation, Redirect, Link as RouterLink } from 'react-router-dom';
 import './NavBar.css';
 import { fade, makeStyles } from '@material-ui/core/styles';
 import {UserContext} from '../../contexts/UserContext';
-import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 import Button from '@material-ui/core/Button';
-import { Typography, Menu, MenuItem, Badge, IconButton, AppBar, Toolbar, InputBase, Avatar, Grid, Box, Collapse, TextField, Link } from '@material-ui/core';
+import { Typography, Menu, MenuItem, Badge, IconButton, AppBar, Toolbar, InputBase, Grid, Box, Collapse, TextField, Link, Dialog, DialogTitle, DialogContent } from '@material-ui/core';
 import { Mail as MailIcon, Search as SearchIcon, AccountCircle, More as MoreIcon, Menu as MenuIcon, Notifications as NotificationsIcon} from '@material-ui/icons';
 import Hoverable from '../Interface/Hoverable';
+import Avatar from 'react-avatar';
 
 const useStyles = makeStyles(theme => ({
     grow: {
@@ -83,9 +83,41 @@ const AccountOptions = () => {
     )
 }
 
-const UserBar = () => {
+const SimpleDialog = (props) => {
+    const classes = useStyles();
+    const { onClose, selectedValue, open } = props;
+  
+    const handleClose = () => {
+      onClose(selectedValue);
+    };
+  
+    const handleListItemClick = value => {
+      onClose(value);
+    };
 
-}
+    return (
+      <Dialog onClose={handleClose} aria-labelledby="simple-dialog-title" open={open} style={{textAlign: "center"}}>
+          
+        <DialogTitle id="simple-dialog-title">
+            <div><Avatar round={true} size="3rem" color={Avatar.getRandomColor('sitebase', ['#2BCED6', '#222831', '#393E46','#00ADB5'])} name={`${props.user.firstname}` + " " + `${props.user.lastname}`}/></div>
+            {props.user.username}</DialogTitle>
+        <DialogContent>
+            <div>{props.user.firstname} {props.user.lastname}</div>
+            <div>{props.user.email}</div>
+            <Box mt={3}>
+                <Grid container direction="row" justify="center">
+                    <Grid item xs={8} sm={4}>
+                        <Button color="primary" component={RouterLink} to={'/User/ChangeUsername'} onClick={handleClose}>Change Username</Button>
+                    </Grid>
+                    <Grid item xs={8} sm={4}>
+                        <Button color="primary" component={RouterLink} to={'/User/ChangePassword'} onClick={handleClose}>Change Password</Button>
+                    </Grid>
+                </Grid>
+            </Box>
+        </DialogContent>
+      </Dialog>
+    );
+  }
 
 function SearchBar(){
     const classes = useStyles();
@@ -133,6 +165,17 @@ function Logo(){
 
 export default function NavBar() {
     const classes = useStyles();
+    const [open, setOpen] = React.useState(false);
+    const [selectedValue, setSelectedValue] = React.useState();
+  
+    const handleClickOpen = () => {
+      setOpen(true);
+    };
+  
+    const handleClose = value => {
+      setOpen(false);
+      setSelectedValue(value);
+    };
 
     return(
         <div className={classes.grow}>
@@ -141,23 +184,20 @@ export default function NavBar() {
                     <Grid container alignItems='center'>
                         {['Course', 'Blog'].map((route, index) =>{
                             return(
-                                <Grid key={index} item xs={12} sm={1} container justify='center'>
+                                <Grid key={index} item xs={11} sm={1} container justify='center'>
                                     <Link href={`/${route}/`} color='inherit'>
                                         {route + 's'}
                                     </Link>
                                 </Grid>
                             )
                         })}
-                        <Grid item xs={12} sm={3} container justify='center'>
+                        {/* <Grid item xs={11} sm={3} container justify='center'>
                             <SearchBar/>
-                        </Grid>
-                        <Grid item xs={12} sm={2} container justify='center'>
-                            <Logo/>
-                        </Grid>
-                        <Grid item container xs={12} sm={3}>
-                            {['Donate', 'Store'].map((route, index) => {
+                        </Grid> */}
+                        <Grid item container xs={11} sm={2}>
+                            {['Store'].map((route, index) => {
                                 return(
-                                    <Grid key={index} item xs={12} sm={6} container justify='center'>
+                                    <Grid key={index} item xs={13} sm={6} container justify='center'>
                                         <Link href={`/${route}/`} color='inherit'>
                                             {route}
                                         </Link>
@@ -165,8 +205,26 @@ export default function NavBar() {
                                 )
                             })}
                         </Grid>
-                        <Grid item xs={12} sm={2}>
+                        <Grid item xs={11} sm={4} container justify='center'>
+                            <Logo/>
+                        </Grid>
+                        <Grid item xs={11} sm={2}>
                             <AccountOptions/>
+                        </Grid>
+                        <Grid item xs={11} sm={2} justify='center'>
+                            <UserContext.Consumer>{context => {
+                                if(context.isAuthenticated()) {
+                                    return(
+                                        <div>
+                                        <Button onClick={handleClickOpen}>
+                                            <Avatar round={true} size="3rem" color={Avatar.getRandomColor('sitebase', ['#2BCED6', '#222831', '#393E46','#00ADB5'])} name={`${context.user.firstname}` + " " + `${context.user.lastname}`}/>
+                                        </Button>    
+                                        <SimpleDialog selectedValue={selectedValue} open={open} onClose={handleClose} user={context.user}/>
+                                        </div>
+        
+                                    )
+                                }
+                            }}</UserContext.Consumer>
                         </Grid>
                     </Grid>
                 </Toolbar>

--- a/client/src/views/User/Profile/ChangePassword.js
+++ b/client/src/views/User/Profile/ChangePassword.js
@@ -1,0 +1,142 @@
+import './Profile.css';
+import React, {useContext, useState, useEffect} from 'react';
+import { UserContext } from '../../../contexts/UserContext';
+import { Redirect, Link as RouterLink} from 'react-router-dom';
+import { CssBaseline, TextField, Typography, makeStyles, Box, Container, Grid } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import API from '../../../modules/API'
+import Avatar from 'react-avatar';
+
+const useStyles = makeStyles(theme => ({
+    paper: {
+      marginTop: theme.spacing(8),
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+    },
+    avatar: {
+      margin: theme.spacing(1),
+      backgroundColor: theme.palette.secondary.light,
+    },
+    form: {
+      width: '100%', // Fix IE 11 issue.
+      marginTop: theme.spacing(1),
+    },
+    formField: {
+        color: theme.palette.primary.light,
+    },
+    submit: {
+      margin: theme.spacing(3, 0, 2),
+      backgroundColor: theme.palette.secondary.dark,
+      "&:hover":{
+          backgroundColor: theme.palette.secondary.light,
+      }
+    },
+    error: {
+        color: 'red'
+    }
+  }));
+
+const ChangePassword = () => {
+    const classes = useStyles();
+    const userInfo = useContext(UserContext);
+    const [message, setMessage] = useState('');
+    const [changed, isChanged] = useState(false);
+    const [oldpassword, setOldPassword] = useState("");
+    const [newpassword, setNewPassword] = useState("");
+    const [confirmPassword, setConfirmedPassword] = useState("");
+
+
+    const handleSubmit = () => {
+
+    }
+
+    if(changed) {
+        window.location.pathname="/Home"; 
+        return false;
+    }
+    return(
+        <UserContext.Consumer>{context => {
+            if(context.isAuthenticated()) {
+                return(
+                    <Container component="main" maxWidth="xs">
+                    <CssBaseline/>
+                    <div className={classes.paper}>
+                        <Typography component="h1" variant="h5">
+                            Change Password
+                        </Typography>
+                        <TextField
+                            variant='filled'
+                            margin="normal"
+                            required
+                            fullWidth
+                            id="oldpassword"
+                            label="Old Password"
+                            name="oldpassword"
+                            type="password"
+                            autoFocus
+                            className={classes.formField}
+                            onChange={(e) => {setOldPassword(e.target.value)}}
+                        />
+                        <TextField
+                            variant="filled"
+                            margin="normal"
+                            required
+                            fullWidth
+                            name="newpassword"
+                            label="New Password"
+                            id="newpassword"
+                            type="password"
+                            className={classes.formField}
+                            onChange={(e) => {setNewPassword(e.target.value)}}
+                        />
+                        <TextField
+                            variant="filled"
+                            margin="normal"
+                            required
+                            fullWidth
+                            name="confirmpassword"
+                            label="Confirm Password"
+                            id="confirmpassword"
+                            type="password"
+                            className={classes.formField}
+                            onChange={(e) => {setConfirmedPassword(e.target.value)}}
+                        />
+                        {message ? <Typography className={classes.error}>
+                            {message}
+                        </Typography> : <React.Fragment/>}
+                        <Grid container spacing={5} justify="center">
+                            <Grid item xs={10} sm={5}>
+                                <Button
+                                fullWidth
+                                variant="contained"
+                                color="primary"
+                                className={classes.submit}
+                                onClick={handleSubmit}
+                            >
+                                Confirm
+                                </Button> 
+                            </Grid>
+                            <Grid item xs={10} sm={5}>
+                                <Button
+                                fullWidth
+                                variant="contained"
+                                color="primary"
+                                className={classes.submit}
+                                component={RouterLink} to={'/Home'}
+                            >
+                                Cancel
+                                </Button> 
+                            </Grid>
+                        </Grid>
+                    </div>
+                    </Container>
+                )
+                }
+            }
+        }
+        </UserContext.Consumer>
+    );
+
+}
+export default ChangePassword

--- a/client/src/views/User/Profile/ChangeUsername.js
+++ b/client/src/views/User/Profile/ChangeUsername.js
@@ -1,0 +1,152 @@
+import './Profile.css';
+import React, {useContext, useState, useEffect} from 'react';
+import { UserContext } from '../../../contexts/UserContext';
+import { Redirect, Link as RouterLink} from 'react-router-dom';
+import { CssBaseline, TextField, Typography, makeStyles, Box, Container, Grid } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import API from '../../../modules/API'
+import Avatar from 'react-avatar';
+
+const useStyles = makeStyles(theme => ({
+    paper: {
+      marginTop: theme.spacing(8),
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+    },
+    avatar: {
+      margin: theme.spacing(1),
+      backgroundColor: theme.palette.secondary.light,
+    },
+    form: {
+      width: '100%', // Fix IE 11 issue.
+      marginTop: theme.spacing(1),
+    },
+    formField: {
+        color: theme.palette.primary.light,
+    },
+    submit: {
+      margin: theme.spacing(3, 0, 2),
+      backgroundColor: theme.palette.secondary.dark,
+      "&:hover":{
+          backgroundColor: theme.palette.secondary.light,
+      }
+    },
+    error: {
+        color: 'red'
+    }
+  }));
+
+const ChangeUsername = () => {
+    const classes = useStyles();
+    const userInfo = useContext(UserContext);
+    const [message, setMessage] = useState('');
+    const [changed, isChanged] = useState(false);
+    const [username, setUsername] = useState(userInfo.user.username);
+    const [password, setPassword] = useState("");
+
+
+    const handleSubmit = () => {
+        if (password === "") {
+            setMessage("Please include your password.");
+        }
+        else if(username === userInfo.user.username || username === "") {
+            setMessage("Please create a new username.");
+        }
+        else {
+            API.post('/api/checkusernamenotexist', {
+                username: username
+            }).then(res => {
+                API.post('/api/updateusername', {
+                    password: password,
+                    username: username,
+                    oldUsername: userInfo.user.username,
+                    email: userInfo.user.email
+                }).then(res => {
+                    if(res.status == 200) {alert("Username changed!"); isChanged(true); };
+                }).catch(err =>{
+                    setMessage("Incorrect password.")
+                })
+            }).catch(err => {
+                setMessage("Please use a different username.");
+            })
+        }
+    }
+
+    if(changed) {
+        window.location.pathname="/Home"; 
+        return false;
+    }
+    return(
+        <UserContext.Consumer>{context => {
+            if(context.isAuthenticated()) {
+                return(
+                    <Container component="main" maxWidth="xs">
+                    <CssBaseline/>
+                    <div className={classes.paper}>
+                        <Typography component="h1" variant="h5">
+                            Change Username
+                        </Typography>
+                        <TextField
+                            variant='filled'
+                            margin="normal"
+                            required
+                            fullWidth
+                            id="username"
+                            label="Username"
+                            name="username"
+                            autoFocus
+                            className={classes.formField}
+                            defaultValue={userInfo.user.username}
+                            onChange={(e) => {setUsername(e.target.value)}}
+                        />
+                        <TextField
+                            variant="filled"
+                            margin="normal"
+                            required
+                            fullWidth
+                            name="password"
+                            label="Password"
+                            type="password"
+                            id="password"
+                            className={classes.formField}
+                            onChange={(e) => {setPassword(e.target.value)}}
+                        />
+                        {message ? <Typography className={classes.error}>
+                            {message}
+                        </Typography> : <React.Fragment/>}
+                        <Grid container spacing={5} justify="center">
+                            <Grid item xs={10} sm={5}>
+                                <Button
+                                fullWidth
+                                variant="contained"
+                                color="primary"
+                                className={classes.submit}
+                                onClick={handleSubmit}
+                            >
+                                Confirm
+                                </Button> 
+                            </Grid>
+                            <Grid item xs={10} sm={5}>
+                                <Button
+                                fullWidth
+                                variant="contained"
+                                color="primary"
+                                className={classes.submit}
+                                component={RouterLink} to={'/Home'}
+                            >
+                                Cancel
+                                </Button> 
+                            </Grid>
+                        </Grid>
+                    </div>
+                    </Container>
+                )
+                }
+            }
+        }
+        </UserContext.Consumer>
+    );
+
+}
+export default ChangeUsername

--- a/client/src/views/User/Profile/Profile.js
+++ b/client/src/views/User/Profile/Profile.js
@@ -3,7 +3,6 @@ import './Profile.css';
 import { UserContext } from '../../../contexts/UserContext';
 import { Redirect } from 'react-router-dom';
 import { CssBaseline, TextField, Typography, makeStyles, Box } from '@material-ui/core';
-import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 import Button from '@material-ui/core/Button';
 import API from '../../../modules/API'
 import Avatar from 'react-avatar';
@@ -68,7 +67,7 @@ const ChangeUser = () => {
     {
         return(
             <div>
-                <TextField label="Username" onChange={e => {setOldUser(e.target.value)}} variant="standard" id="newuser" defaultValue={userInfo.user.username} autoFocus/>
+                <TextField label="Username" onChange={e => {setOldUser(e.target.value)}} variant="standard" id="newuser"  autoFocus/>
                 <div>
                     <TextField label="Password" type="password" onChange={e => {setPassword(e.target.value)}} variant="standard" id="confirmpass"/>
                 </div>

--- a/client/src/views/User/User.js
+++ b/client/src/views/User/User.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
 // import './User.css';
-import Profile from "./Profile/Profile";
 import Login from "./Login/Login";
 import SignUp from "./SignUp/SignUp";
 import ForgotPassword from "./ForgotPassword/ForgotPassword";
+import ChangePassword from "./Profile/ChangePassword"
+import ChangeUsername from "./Profile/ChangeUsername"
 import { CssBaseline } from '@material-ui/core';
 import {UserContext} from '../../contexts/UserContext'
 
@@ -25,9 +26,10 @@ export default function User({match}) {
             <Switch>
                 <Route path={`${match.path}/ForgotPassword`} component={ForgotPassword} />
                 <Route path={`${match.path}/Login`} component={Login} />
-                <Route path={`${match.path}/Profile`} component={Profile} />
                 <Route path={`${match.path}/SignUp`} component={SignUp} />
                 <Route path={`${match.path}/Logout`} component={LogOut} />
+                <Route path={`${match.path}/ChangePassword`} component={ChangePassword} />
+                <Route path={`${match.path}/ChangeUsername`} component={ChangeUsername} />
             </Switch>
         </CssBaseline>
     );


### PR DESCRIPTION
Because of how empty the user page was, Spencer and I thought it'd be a good idea to create a small dialog page (it'll just hover over what page you are currently at) and then select the action you want to do (change username or password). If you click outside the page, it'll go away. If you click one of the buttons, it will direct you to a change user or password form. Currently, the change user form is set. The password form is almost done. I still have the old code of Profile.js there to make that the method of the original plan is still there.